### PR TITLE
Update rsyslog example configuration

### DIFF
--- a/content/integrations/data-shippers/rsyslog.md
+++ b/content/integrations/data-shippers/rsyslog.md
@@ -24,30 +24,20 @@ Create a file named `/etc/rsyslog.d/33-humio.conf` with the following contents
 
 ```groovy
 module(load="omelasticsearch")
-template(name="humiotemplate"
-         type="list"
-         option.json="on") {
-           constant(value="{")
-             constant(value="\"@timestamp\":\"")
-                property(name="timereported" dateFormat="rfc3339")
-                constant(value="\",")
-             constant(value="\"message\":\"")
-                property(name="msg")
-                constant(value="\",")
-             constant(value="\"host\":\"")
-                property(name="hostname")
-                constant(value="\",")
-             constant(value="\"severity\":\"")
-                property(name="syslogseverity-text")
-                constant(value="\",")
-             constant(value="\"facility\":\"")
-                property(name="syslogfacility-text")
-                constant(value="\",")
-             constant(value="\"syslogtag\":\"")
-                property(name="syslogtag")
-                constant(value="\"")
-           constant(value="}")
-         }
+
+template(name="humiotemplate" type="list" option.json="on") {
+  constant(value="{")
+    constant(value="\"@timestamp\":\"") property(name="timereported" dateFormat="rfc3339")
+    constant(value="\",\"message\":\"") property(name="msg")
+    constant(value="\",\"host\":\"") property(name="hostname")
+    constant(value="\",\"severity\":\"") property(name="syslogseverity-text")
+    constant(value="\",\"facility\":\"") property(name="syslogfacility-text")
+    constant(value="\",\"syslogtag\":\"") property(name="syslogtag")
+    constant(value="\",\"name\":\"") property(name="programname")
+    constant(value="\",\"pid\":\"") property(name="procid")
+  constant(value="\"}")
+}
+
 *.* action(type="omelasticsearch"
            server="$HOST"
            template="humiotemplate"
@@ -55,6 +45,7 @@ template(name="humiotemplate"
            pwd="none"
            bulkmode="on"
            usehttps="on")
+
 ```
 
 Remember to replace `$HOST` with your Humio host, i.e. `cloud.humio.com`


### PR DESCRIPTION
I propose the following change to the rsyslog documentation minimal configuration. It makes it easier to query Humio for specific program output (by `name`), even after restarts when the PID changes, without having to mangle the name and/or PID out of the `syslogtag`.

## Commit message

The properties `programname` and `procid` have been added to the JSON output under the keys `name` and `pid`, respectively.

Also, the formatting has been simplified slightly to have fewer `constant` expressions.