### PR TITLE
Add notices about separate kafka partitions/volumes

### DIFF
--- a/content/installation/cluster_setup.md
+++ b/content/installation/cluster_setup.md
@@ -95,6 +95,13 @@ For each machine do:
     $ mkdir -p /data/kafka-data
     $ chown -R humio:humio /data/kafka-data
     ```
+{{% notice info %}}
+Make sure Kafka's mount point is on a separate volume from the others. Kafka is notorious for
+consuming large amounts of disk space, so it's important to protect the other services from
+running out of disk by using a separate volume in production deployments.
+Make sure all volumes are being appropriately monitored as well. If your installation does
+run out of disk space and gets into a bad state, you can find recovery instructions [here]({{< ref "configuration/kafka-switch.md" >}}).
+{{% /notice %}}
 
 7. Create a configuration file for Kafka. Each server needs to have a unique name and an `broker.id`  (`1`, `2` or `3`). Make sure the listener is something the humio instances can reach. If in doubt, please refer to the Kafka documentation. Here is the configuration file for `HOST`, remember to set `broker.id` and `listeners` accordingly. Save it a known location, such as `/etc/humio/kafka.properties`
 

--- a/content/installation/docker.md
+++ b/content/installation/docker.md
@@ -36,11 +36,19 @@ These settings are for a machine with 8GB of RAM or more.
 
 **Step 3**
 
-Create an empty directory on the host machine to store data for Humio:
+Create empty directories on the host machine to store data for Humio:
 
 ```shell
-mkdir humio-data
+mkdir -p mounts/data mounts/kafka-data
 ```
+
+{{% notice info %}}
+Separate mount points help isolate Kafka from the other services. Kafka is notorious for
+consuming large amounts of disk space, so it's important to protect the other services from
+running out of disk by using a separate volume in production deployments.
+Make sure all volumes are being appropriately monitored as well. If your installation does
+run out of disk space and gets into a bad state, you can find recovery instructions [here]({{< ref "configuration/kafka-switch.md" >}}).
+{{% /notice %}}
 
 **Step 4**
 
@@ -55,12 +63,14 @@ docker pull humio/humio
 Run the Humio Docker image as a container:
 
 ```shell
-docker run -v $HOST_DATA_DIR:/data -v $PATH_TO_READONLY_FILES:/etc/humio:ro --net=host --name=humio --ulimit="nofile=8192:8192" --env-file=$PATH_TO_CONFIG_FILE humio/humio
+docker run -v $HOST_DATA_DIR:/data -v $HOST_KAFKA_DATA_DIR:/data/kafka-data -v $PATH_TO_READONLY_FILES:/etc/humio:ro --net=host --name=humio --ulimit="nofile=8192:8192" --env-file=$PATH_TO_CONFIG_FILE humio/humio
 ```
 
-Replace `$HOST_DATA_DIR` with the path to the humio-data directory you created
-on the host machine, and `$PATH_TO_CONFIG_FILE` with the path of the
-configuration file you created. The directory `$PATH_TO_READONLY_FILES` provides a place to put files that are needed at runtime by humio such as certificates for SAML authentication.
+Replace `$HOST_DATA_DIR` with the path to the mounts/data directory you created
+on the host machine, `$HOST_KAFKA_DATA_DIR` with the path to the mounts/kafka-data
+directory, and `$PATH_TO_CONFIG_FILE` with the path of the configuration file you
+created. The directory `$PATH_TO_READONLY_FILES` provides a place to put files that
+are needed at runtime by humio such as certificates for SAML authentication.
 
 **Step 6**
 

--- a/content/installation/preparation.md
+++ b/content/installation/preparation.md
@@ -51,3 +51,18 @@ EOF
 **These settings apply to the next login of the Humio user, not to any running processes.**
 
 If you run Humio using Docker then you can raise the limit using the `--ulimit="nofile=8192:8192"` option on the `docker run` command.
+
+## Use a Separate Disk for Kafka Data
+
+For production usage, you should ensure Kafka's data volume is on a separate
+disk/volume from the other Humio services. This is because it's quite easy for
+Kafka to fill the disk it's using if Humio ingestion is slowed down for any
+reason. If it fills its disk, having it on a separate disk/volume than the other
+services will prevent them from crashing along with Kafka and will make recovery
+easier. If Kafka is running as separate servers or containers, you will likely be
+covered already, so this is primarily for situations where you're running the
+all-in-one docker image we supply.
+
+We also **highly** recommend setting up your own disk usage monitoring to alert
+when disks get > 80% full so you can take corrective action before the disk fills
+completely.


### PR DESCRIPTION
We recommend having Kafka's data stored on a separate disk/volume from the other Humio installation data. This is because Kafka has a tendency of consuming large amounts of disk and it's easy to accidentally run out of disk space. If that happens, we want to protect other services from running out of disk space. This adds some notices to bring this to top of mind when installing Humio for the first time.