### PR TITLE
Add warnings about docker env-file usage

### DIFF
--- a/content/configuration/_index.md
+++ b/content/configuration/_index.md
@@ -12,6 +12,13 @@ When running Humio in Docker you can pass set the `--env-file=` flag and keep
 your configuration in a file. For a quick intro to setting configuration options
 see the documentation for [installation on docker]({{< ref "docker.md" >}}).
 
+{{% notice info %}}
+Docker only loads the environment file **when the container is initially created**.
+As such, if you make changes to the settings in your environment file, simply
+stopping and starting the container will not work. You need to `docker rm` the
+container and `docker run` it again to pick up changes.
+{{% /notice %}}
+
 ## Example configuration {#example-configuration-file-with-comments}
 
 ```properties

--- a/content/installation/cluster_setup.md
+++ b/content/installation/cluster_setup.md
@@ -218,6 +218,12 @@ Humio is distributed as Docker images; use the `humio/humio-core` edition for di
     # Select the IP to bind the http listening socket to. (Defaults to HUMIO_SOCKET_BIND)
     #HUMIO_HTTP_BIND=0.0.0.0
     ```
+{{% notice info %}}
+Docker only loads the environment file **when the container is initially created**.
+As such, if you make changes to the settings in your environment file, simply
+stopping and starting the container will not work. You need to `docker rm` the
+container and `docker run` it again to pick up changes.
+{{% /notice %}}
 
 3. Create an empty directory on the host machine to store data for Humio:
 

--- a/content/installation/docker.md
+++ b/content/installation/docker.md
@@ -20,6 +20,13 @@ For example, `humio.conf`.
 
 You can use this file to pass on JVM arguments to the Humio Java process.
 
+{{% notice info %}}
+Docker only loads the environment file **when the container is initially created**.
+As such, if you make changes to the settings in your environment file, simply
+stopping and starting the container will not work. You need to `docker rm` the
+container and `docker run` it again to pick up changes.
+{{% /notice %}}
+
 **Step 2**
 
 Enter the following settings into the configuration file:


### PR DESCRIPTION
Docker only loads the contents of `--env-file` when a container is created. If you modify your Humio settings, you need to `docker rm` the container and `docker run` a new one to pick up your changes. Simply doing a `docker stop` and `docker start` on the container won't pick up any changes.