### PR TITLE
Update limits documentation for MAX_STATE_LIMIT

### DIFF
--- a/content/appendix/limits.md
+++ b/content/appendix/limits.md
@@ -13,7 +13,7 @@ This page lists the various limits that Humio has.
 | Max number of fields in an event| 1000 |
 | Max event size | 1M bytes |
 | Max length of query | 66k characters|
-| Max number of elements in a [groupby]({{< ref "/query-functions/_index.md#groupBy">}}) | 20k | Can be disabled using the `ALLOW_UNLIMITED_STATESIZE` configuration
+| Max number of elements in a [groupby]({{< ref "/query-functions/_index.md#groupBy">}}) | 20k | Can be changed using the `MAX_STATE_LIMIT` configuration
 | Max number of events in a [tail]({{< ref "/query-functions/_index.md#tail">}}) | 10k | -
 | Max number of datasources in a repository | 10k | Can be changed using the `MAX_DATASOURCES` configuration
 


### PR DESCRIPTION
In Humio 1.2.2 this change was documented:

> Configuration change. `ALLOW_UNLIMITED_STATE_SIZE` has been replaced by `MAX_STATE_LIMIT`. `MAX_STATE_LIMIT` limits state size in Humio searches and now allows specifying a number. For example the number of groups in the groupBy function is limited by `MAX_STATE_LIMIT`.

but the docs for limits was never updated to reflect the change.