### PR TITLE
Add tip about increasing proxy_read_timeout

### DIFF
--- a/content/configuration/reverse-proxy/nginx-reverse-proxy.md
+++ b/content/configuration/reverse-proxy/nginx-reverse-proxy.md
@@ -42,7 +42,7 @@ your `/home/humio/humio-config.env`.
 The `proxy_read_timeout` setting above may be too low for longer operations like exporting
 query results from large queries involving aggregate data. If you find requests like
 that are timing out after 25 seconds, then you should increase the `proxy_read_timeout`
-value to accomodate what you need.
+value to accommodate what you need.
 {{% /notice %}}
 
 ## Example for a cluster with multiple hosts

--- a/content/configuration/reverse-proxy/nginx-reverse-proxy.md
+++ b/content/configuration/reverse-proxy/nginx-reverse-proxy.md
@@ -39,8 +39,8 @@ there is a fall-back solution: You can set `PROXY_PREFIX_URL` in
 your `/home/humio/humio-config.env`.
 
 {{% notice tip %}}
-The `proxy_read_timeout` setting above may be to low for longer operations like exporting
-query results from large queries involving aggregate data. If you find that requests like
+The `proxy_read_timeout` setting above may be too low for longer operations like exporting
+query results from large queries involving aggregate data. If you find requests like
 that are timing out after 25 seconds, then you should increase the `proxy_read_timeout`
 value to accomodate what you need.
 {{% /notice %}}

--- a/content/configuration/reverse-proxy/nginx-reverse-proxy.md
+++ b/content/configuration/reverse-proxy/nginx-reverse-proxy.md
@@ -38,6 +38,13 @@ If it is not feasible for you to add the header `X-Forwarded-Prefix` in your pro
 there is a fall-back solution: You can set `PROXY_PREFIX_URL` in
 your `/home/humio/humio-config.env`.
 
+{{% notice tip %}}
+The `proxy_read_timeout` setting above may be to low for longer operations like exporting
+query results from large queries involving aggregate data. If you find that requests like
+that are timing out after 25 seconds, then you should increase the `proxy_read_timeout`
+value to accomodate what you need.
+{{% /notice %}}
+
 ## Example for a cluster with multiple hosts
 
 ```nginx


### PR DESCRIPTION
If people use our default nginx config file, they can run into situations where longer operations like an export of a large aggregate query might hit the 25s `proxy_read_timeout` limit. This adds a tip to the nginx page pointing this out.